### PR TITLE
Fix build. Add BTreeInnerTupleGetDownLink define

### DIFF
--- a/gevel.c
+++ b/gevel.c
@@ -48,6 +48,9 @@
 #include <access/brin_tuple.h>
 #endif
 
+/* Get downlink block number */
+#define BTreeInnerTupleGetDownLink(itup) \
+	ItemPointerGetBlockNumberNoCheck(&((itup)->t_tid))
 
 #define PAGESIZE	(BLCKSZ - MAXALIGN(sizeof(PageHeaderData) + sizeof(ItemIdData)))
 
@@ -905,7 +908,7 @@ gin_stat(PG_FUNCTION_ARGS) {
 #else
 	result = TupleGetDatum(funcctx->slot, htuple);
 #endif
-	
+
 	SRF_RETURN_NEXT(funcctx, result);
 }
 


### PR DESCRIPTION
@pramsey I have a warning (but an error at runtime), because of `BTreeInnerTupleGetDownLink` function

```make
gevel.c:1663:11: warning: implicit declaration of function 'BTreeInnerTupleGetDownLink' is invalid in C99 [-Wimplicit-function-declaration]
                        cblk = BTreeInnerTupleGetDownLink(itup);
                               ^
gevel.c:2011:21: warning: implicit declaration of function 'BTreeInnerTupleGetDownLink' is invalid in C99 [-Wimplicit-function-declaration]
                BlockNumber blk = BTreeInnerTupleGetDownLink(ituple);
```

I fix it using the code [from zheap](https://github.com/EnterpriseDB/zheap/blob/master/src/include/access/nbtree.h#L300-L302)


